### PR TITLE
chore: eslint 관련 설정 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,9 +4,29 @@
     "plugin:tailwindcss/recommended",
     "prettier",
     "plugin:storybook/recommended"
+    // "plugin:@typescript-eslint/recommended"
   ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint", "@tanstack/query", "simple-import-sort"],
   "ignorePatterns": ["!.storybook", "storybook-static"],
   "rules": {
-    "no-console": "warn"
+    "no-console": "warn",
+    "@tanstack/query/exhaustive-deps": "error",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "simple-import-sort/imports": [
+      "error",
+      {
+        "groups": [
+          ["^react.*", "^next.*", "^@?\\w"],
+          ["^@/.*"],
+          ["^(?:../|./)(?!.*.css$).*$"],
+          ["^.+\\.css$"]
+        ]
+      }
+    ]
   }
 }

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,10 +1,12 @@
+import React from 'react'
+import localFont from 'next/font/local'
+import { Session } from 'next-auth'
 import type { Preview } from '@storybook/react'
 import { QueryClient } from '@tanstack/react-query'
-import { Session } from 'next-auth'
-import localFont from 'next/font/local'
-import React from 'react'
-import '../src/app/globals.css'
+
 import { Providers } from '../src/app/providers'
+
+import '../src/app/globals.css'
 export const pretendard = localFont({
   src: '../fonts/PretendardVariable.woff2',
   variable: '--font-pretendard',

--- a/package.json
+++ b/package.json
@@ -66,12 +66,15 @@
     "@storybook/nextjs": "^8.1.11",
     "@storybook/react": "^8.1.11",
     "@storybook/test": "^8.1.11",
+    "@tanstack/eslint-plugin-query": "^5.51.10",
     "@testing-library/react": "^14.2.1",
     "@tomfreudenberg/next-auth-mock": "^0.5.6",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/react-highlight-words": "^0.20.0",
+    "@typescript-eslint/eslint-plugin": "^7.16.1",
+    "@typescript-eslint/parser": "^7.16.1",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.0.1",
     "chromatic": "^11.3.0",
@@ -79,6 +82,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.1.1",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-storybook": "^0.8.0",
     "eslint-plugin-tailwindcss": "^3.14.3",
     "husky": "^9.0.11",
@@ -95,7 +99,7 @@
   "lint-staged": {
     "*.{js,ts,tsx}": [
       "prettier --write",
-      "eslint --max-warnings 0 .",
+      "eslint --fix",
       "vitest related --run"
     ]
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@storybook/test':
         specifier: ^8.1.11
         version: 8.1.11(vitest@1.6.0(@types/node@20.14.9)(jsdom@24.1.0)(terser@5.31.1))
+      '@tanstack/eslint-plugin-query':
+        specifier: ^5.51.10
+        version: 5.51.10(eslint@8.57.0)(typescript@5.5.2)
       '@testing-library/react':
         specifier: ^14.2.1
         version: 14.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -168,6 +171,12 @@ importers:
       '@types/react-highlight-words':
         specifier: ^0.20.0
         version: 0.20.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.16.1
+        version: 7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
+      '@typescript-eslint/parser':
+        specifier: ^7.16.1
+        version: 7.16.1(eslint@8.57.0)(typescript@5.5.2)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.3.1(vite@5.3.2(@types/node@20.14.9)(terser@5.31.1))
@@ -189,6 +198,9 @@ importers:
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@8.57.0)
+      eslint-plugin-simple-import-sort:
+        specifier: ^12.1.1
+        version: 12.1.1(eslint@8.57.0)
       eslint-plugin-storybook:
         specifier: ^0.8.0
         version: 0.8.0(eslint@8.57.0)(typescript@5.5.2)
@@ -2462,6 +2474,11 @@ packages:
   '@swc/helpers@0.5.2':
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
 
+  '@tanstack/eslint-plugin-query@5.51.10':
+    resolution: {integrity: sha512-XThVzwiPEVtwS4IOvTloSR4WtPS7+Y9CWkIoQwcGUJgWFHd3P6geRWV/BoE4I3UM2uJDBx/Nyp7+6eLlsvN5mQ==}
+    peerDependencies:
+      eslint: ^8 || ^9
+
   '@tanstack/query-core@5.49.1':
     resolution: {integrity: sha512-JnC9ndmD1KKS01Rt/ovRUB1tmwO7zkyXAyIxN9mznuJrcNtOrkmOnQqdJF2ib9oHzc2VxHomnEG7xyfo54Npkw==}
 
@@ -2668,11 +2685,32 @@ packages:
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
+  '@typescript-eslint/eslint-plugin@7.16.1':
+    resolution: {integrity: sha512-SxdPak/5bO0EnGktV05+Hq8oatjAYVY3Zh2bye9pGZy6+jwyR3LG3YKkV4YatlsgqXP28BTeVm9pqwJM96vf2A==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^7.0.0
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/parser@6.21.0':
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/parser@7.16.1':
+    resolution: {integrity: sha512-u+1Qx86jfGQ5i4JjK33/FnawZRpsLxRnKzGE6EABZ40KxVT/vWsiZFEBBHjFOljmmV3MBYOHEKi0Jm9hbAOClA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -2686,6 +2724,24 @@ packages:
     resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
+  '@typescript-eslint/scope-manager@7.16.1':
+    resolution: {integrity: sha512-nYpyv6ALte18gbMz323RM+vpFpTjfNdyakbf3nsLvF43uF9KeNC289SUEW3QLZ1xPtyINJ1dIsZOuWuSRIWygw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/scope-manager@8.0.0-alpha.30':
+    resolution: {integrity: sha512-FGW/iPWGyPFamAVZ60oCAthMqQrqafUGebF8UKuq/ha+e9SVG6YhJoRzurlQXOVf8dHfOhJ0ADMXyFnMc53clg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/type-utils@7.16.1':
+    resolution: {integrity: sha512-rbu/H2MWXN4SkjIIyWcmYBjlp55VT+1G3duFOIukTNFxr9PI35pLc2ydwAfejCEitCv4uztA07q0QWanOHC7dA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/types@5.62.0':
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2693,6 +2749,14 @@ packages:
   '@typescript-eslint/types@6.21.0':
     resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/types@7.16.1':
+    resolution: {integrity: sha512-AQn9XqCzUXd4bAVEsAXM/Izk11Wx2u4H3BAfQVhSfzfDOm/wAON9nP7J5rpkCxts7E5TELmN845xTUCQrD1xIQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/types@8.0.0-alpha.30':
+    resolution: {integrity: sha512-4WzLlw27SO9pK9UFj/Hu7WGo8WveT0SEiIpFVsV2WwtQmLps6kouwtVCB8GJPZKJyurhZhcqCoQVQFmpv441Vg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@5.62.0':
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
@@ -2712,11 +2776,41 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@7.16.1':
+    resolution: {integrity: sha512-0vFPk8tMjj6apaAZ1HlwM8w7jbghC8jc1aRNJG5vN8Ym5miyhTQGMqU++kuBFDNKe9NcPeZ6x0zfSzV8xC1UlQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/typescript-estree@8.0.0-alpha.30':
+    resolution: {integrity: sha512-WSXbc9ZcXI+7yC+6q95u77i8FXz6HOLsw3ST+vMUlFy1lFbXyFL/3e6HDKQCm2Clt0krnoCPiTGvIn+GkYPn4Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/utils@5.62.0':
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@typescript-eslint/utils@7.16.1':
+    resolution: {integrity: sha512-WrFM8nzCowV0he0RlkotGDujx78xudsxnGMBHI88l5J8wEhED6yBwaSLP99ygfrzAjsQvcYQ94quDwI0d7E1fA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+
+  '@typescript-eslint/utils@8.0.0-alpha.30':
+    resolution: {integrity: sha512-rfhqfLqFyXhHNDwMnHiVGxl/Z2q/3guQ1jLlGQ0hi9Rb7inmwz42crM+NnLPR+2vEnwyw1P/g7fnQgQ3qvFx4g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
 
   '@typescript-eslint/visitor-keys@5.62.0':
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
@@ -2725,6 +2819,14 @@ packages:
   '@typescript-eslint/visitor-keys@6.21.0':
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/visitor-keys@7.16.1':
+    resolution: {integrity: sha512-Qlzzx4sE4u3FsHTPQAAQFJFNOuqtuY0LFrZHwQ8IHK705XxBiWOFkfKRWu6niB7hwfgnwIpO4jTC75ozW1PHWg==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/visitor-keys@8.0.0-alpha.30':
+    resolution: {integrity: sha512-XZuNurZxBqmr6ZIRIwWFq7j5RZd6ZlkId/HZEWyfciK+CWoyOxSF9Pv2VXH9Rlu2ZG2PfbhLz2Veszl4Pfn7yA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -3949,6 +4051,11 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+
+  eslint-plugin-simple-import-sort@12.1.1:
+    resolution: {integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-plugin-storybook@0.8.0:
     resolution: {integrity: sha512-CZeVO5EzmPY7qghO2t64oaFM+8FTaD4uzOEjHKp516exyTKo+skKAL9GI3QALS2BXhyALJjNtwbmr1XinGE8bA==}
@@ -9658,6 +9765,14 @@ snapshots:
     dependencies:
       tslib: 2.6.3
 
+  '@tanstack/eslint-plugin-query@5.51.10(eslint@8.57.0)(typescript@5.5.2)':
+    dependencies:
+      '@typescript-eslint/utils': 8.0.0-alpha.30(eslint@8.57.0)(typescript@5.5.2)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@tanstack/query-core@5.49.1': {}
 
   '@tanstack/query-devtools@5.49.1': {}
@@ -9875,12 +9990,43 @@ snapshots:
 
   '@types/uuid@9.0.8': {}
 
+  '@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.11.0
+      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.5.2)
+      '@typescript-eslint/scope-manager': 7.16.1
+      '@typescript-eslint/type-utils': 7.16.1(eslint@8.57.0)(typescript@5.5.2)
+      '@typescript-eslint/utils': 7.16.1(eslint@8.57.0)(typescript@5.5.2)
+      '@typescript-eslint/visitor-keys': 7.16.1
+      eslint: 8.57.0
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      ts-api-utils: 1.3.0(typescript@5.5.2)
+    optionalDependencies:
+      typescript: 5.5.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.5
+      eslint: 8.57.0
+    optionalDependencies:
+      typescript: 5.5.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.16.1
+      '@typescript-eslint/types': 7.16.1
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.5.2)
+      '@typescript-eslint/visitor-keys': 7.16.1
       debug: 4.3.5
       eslint: 8.57.0
     optionalDependencies:
@@ -9898,9 +10044,35 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
 
+  '@typescript-eslint/scope-manager@7.16.1':
+    dependencies:
+      '@typescript-eslint/types': 7.16.1
+      '@typescript-eslint/visitor-keys': 7.16.1
+
+  '@typescript-eslint/scope-manager@8.0.0-alpha.30':
+    dependencies:
+      '@typescript-eslint/types': 8.0.0-alpha.30
+      '@typescript-eslint/visitor-keys': 8.0.0-alpha.30
+
+  '@typescript-eslint/type-utils@7.16.1(eslint@8.57.0)(typescript@5.5.2)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.5.2)
+      '@typescript-eslint/utils': 7.16.1(eslint@8.57.0)(typescript@5.5.2)
+      debug: 4.3.5
+      eslint: 8.57.0
+      ts-api-utils: 1.3.0(typescript@5.5.2)
+    optionalDependencies:
+      typescript: 5.5.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@5.62.0': {}
 
   '@typescript-eslint/types@6.21.0': {}
+
+  '@typescript-eslint/types@7.16.1': {}
+
+  '@typescript-eslint/types@8.0.0-alpha.30': {}
 
   '@typescript-eslint/typescript-estree@5.62.0(typescript@5.5.2)':
     dependencies:
@@ -9931,6 +10103,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@7.16.1(typescript@5.5.2)':
+    dependencies:
+      '@typescript-eslint/types': 7.16.1
+      '@typescript-eslint/visitor-keys': 7.16.1
+      debug: 4.3.5
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.2
+      ts-api-utils: 1.3.0(typescript@5.5.2)
+    optionalDependencies:
+      typescript: 5.5.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.0.0-alpha.30(typescript@5.5.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.0.0-alpha.30
+      '@typescript-eslint/visitor-keys': 8.0.0-alpha.30
+      debug: 4.3.5
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.2
+      ts-api-utils: 1.3.0(typescript@5.5.2)
+    optionalDependencies:
+      typescript: 5.5.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.5.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
@@ -9946,6 +10148,28 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@7.16.1(eslint@8.57.0)(typescript@5.5.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 7.16.1
+      '@typescript-eslint/types': 7.16.1
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.5.2)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/utils@8.0.0-alpha.30(eslint@8.57.0)(typescript@5.5.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 8.0.0-alpha.30
+      '@typescript-eslint/types': 8.0.0-alpha.30
+      '@typescript-eslint/typescript-estree': 8.0.0-alpha.30(typescript@5.5.2)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/visitor-keys@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -9954,6 +10178,16 @@ snapshots:
   '@typescript-eslint/visitor-keys@6.21.0':
     dependencies:
       '@typescript-eslint/types': 6.21.0
+      eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@7.16.1':
+    dependencies:
+      '@typescript-eslint/types': 7.16.1
+      eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@8.0.0-alpha.30':
+    dependencies:
+      '@typescript-eslint/types': 8.0.0-alpha.30
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}
@@ -11393,7 +11627,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.3(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -11421,7 +11655,7 @@ snapshots:
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.14.0
@@ -11443,7 +11677,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.5.2)
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -11453,7 +11697,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.14.0
       is-glob: 4.0.3
@@ -11464,7 +11708,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.2)
+      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.5.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -11515,6 +11759,10 @@ snapshots:
       resolve: 2.0.0-next.5
       semver: 6.3.1
       string.prototype.matchall: 4.0.11
+
+  eslint-plugin-simple-import-sort@12.1.1(eslint@8.57.0):
+    dependencies:
+      eslint: 8.57.0
 
   eslint-plugin-storybook@0.8.0(eslint@8.57.0)(typescript@5.5.2):
     dependencies:

--- a/src/app/(landing)/components/action/index.tsx
+++ b/src/app/(landing)/components/action/index.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
-import { cn } from '@/lib/utils'
+import { HTMLAttributes, useRef } from 'react'
+import Image from 'next/image'
 import { useGSAP } from '@gsap/react'
 import gsap from 'gsap'
 import { ScrollTrigger } from 'gsap/all'
-import Image from 'next/image'
-import { HTMLAttributes, useRef } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 interface ReasonProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const Action = ({ className, ...props }: ReasonProps) => {

--- a/src/app/(landing)/components/feedback/index.tsx
+++ b/src/app/(landing)/components/feedback/index.tsx
@@ -1,6 +1,7 @@
-import { cn } from '@/lib/utils'
-import Image from 'next/image'
 import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
 interface FeedbackProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const Feedback = ({ className, ...props }: FeedbackProps) => {

--- a/src/app/(landing)/components/footer/index.tsx
+++ b/src/app/(landing)/components/footer/index.tsx
@@ -1,8 +1,9 @@
-import { LandingFooterLinks } from '@/config/constants/navigation-links'
-import { cn } from '@/lib/utils'
+import { HTMLAttributes } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { HTMLAttributes } from 'react'
+
+import { LandingFooterLinks } from '@/config/constants/navigation-links'
+import { cn } from '@/lib/utils'
 interface FooterProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const Footer = ({ className, ...props }: FooterProps) => {

--- a/src/app/(landing)/components/hero/index.tsx
+++ b/src/app/(landing)/components/hero/index.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
-import { cn } from '@/lib/utils'
+import { HTMLAttributes, useRef, useState } from 'react'
+import dynamic from 'next/dynamic'
+import Image from 'next/image'
 import { useGSAP } from '@gsap/react'
 import gsap from 'gsap'
-import Image from 'next/image'
-import { HTMLAttributes, useRef, useState } from 'react'
 
-import dynamic from 'next/dynamic'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 const Video = dynamic(
   () => import('@/components/shared/video').then((mod) => mod.Video),
   {

--- a/src/app/(landing)/components/reason/index.tsx
+++ b/src/app/(landing)/components/reason/index.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { cn } from '@/lib/utils'
+import { HTMLAttributes, useRef } from 'react'
+import Image from 'next/image'
 import { useGSAP } from '@gsap/react'
 import gsap from 'gsap'
 import { ScrollTrigger } from 'gsap/all'
-import Image from 'next/image'
-import { HTMLAttributes, useRef } from 'react'
+
+import { cn } from '@/lib/utils'
 interface ReasonProps extends HTMLAttributes<HTMLDivElement> {}
 
 const images = [

--- a/src/app/(landing)/components/recommendation/index.tsx
+++ b/src/app/(landing)/components/recommendation/index.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { cn } from '@/lib/utils'
+import { HTMLAttributes, useRef } from 'react'
 import { useGSAP } from '@gsap/react'
 import gsap from 'gsap'
 import { ScrollTrigger } from 'gsap/all'
-import { HTMLAttributes, useRef } from 'react'
+
+import { cn } from '@/lib/utils'
 interface RecommendationProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const Recommendation = ({

--- a/src/app/(landing)/components/scroll-up-button/index.tsx
+++ b/src/app/(landing)/components/scroll-up-button/index.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
-import { cn } from '@/lib/utils'
+import { HTMLAttributes, useRef } from 'react'
 import { useGSAP } from '@gsap/react'
 import gsap from 'gsap'
 import { ScrollTrigger } from 'gsap/all'
 import { ChevronUp } from 'lucide-react'
-import { HTMLAttributes, useRef } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 interface ScrollUpButtonProps extends HTMLAttributes<HTMLDivElement> {}
 export const ScrollUpButton = ({
   className,

--- a/src/app/(landing)/components/steps/desktop/index.tsx
+++ b/src/app/(landing)/components/steps/desktop/index.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 // import { Video } from '@/components/shared/video'
-import { cn } from '@/lib/utils'
+import { HTMLAttributes, useRef, useState } from 'react'
 import { useGSAP } from '@gsap/react'
 import { ScrollTrigger } from 'gsap/ScrollTrigger'
-import { HTMLAttributes, useRef, useState } from 'react'
+
+import { cn } from '@/lib/utils'
+
 import { StepList } from './step-list'
 import { StepVideos } from './step-videos'
 

--- a/src/app/(landing)/components/steps/desktop/step-videos.tsx
+++ b/src/app/(landing)/components/steps/desktop/step-videos.tsx
@@ -1,7 +1,8 @@
+import { forwardRef, HTMLAttributes, useEffect, useRef } from 'react'
+import dynamic from 'next/dynamic'
+
 import { VideoProps } from '@/components/shared/video'
 import { cn } from '@/lib/utils'
-import dynamic from 'next/dynamic'
-import { HTMLAttributes, forwardRef, useEffect, useRef } from 'react'
 const Video = dynamic(
   () => import('@/components/shared/video').then((mod) => mod.Video),
   {

--- a/src/app/(landing)/components/steps/index.tsx
+++ b/src/app/(landing)/components/steps/index.tsx
@@ -1,5 +1,7 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
+
 import { DesktopSteps } from './desktop'
 import { MobileSteps } from './mobile'
 interface StepsProps extends HTMLAttributes<HTMLDivElement> {}

--- a/src/app/(landing)/components/steps/mobile/index.tsx
+++ b/src/app/(landing)/components/steps/mobile/index.tsx
@@ -1,6 +1,7 @@
+import { HTMLAttributes } from 'react'
+
 import { Video } from '@/components/shared/video'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes } from 'react'
 
 export const MobileSteps = ({
   className,

--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -1,5 +1,6 @@
 import gsap from 'gsap'
 import { ScrollTrigger } from 'gsap/all'
+
 import { Action } from './components/action'
 import { Feedback } from './components/feedback'
 import { Footer } from './components/footer'

--- a/src/app/(routes)/archive/[id]/page.tsx
+++ b/src/app/(routes)/archive/[id]/page.tsx
@@ -1,5 +1,6 @@
-import { ArchiveDetailView } from '@/entities/archives/views/archive-detail-view'
 import { redirect } from 'next/navigation'
+
+import { ArchiveDetailView } from '@/entities/archives/views/archive-detail-view'
 
 interface ArchiveDetail {
   params: {

--- a/src/app/(routes)/archive/create/components/create-archive-form/content-length/index.tsx
+++ b/src/app/(routes)/archive/create/components/create-archive-form/content-length/index.tsx
@@ -1,5 +1,7 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
+
 import { useCreateArchiveFormContext } from '../../../hooks/use-create-archive-form'
 interface ContentLengthProps extends HTMLAttributes<HTMLDivElement> {}
 

--- a/src/app/(routes)/archive/create/components/create-archive-form/fields/company-name-field.tsx
+++ b/src/app/(routes)/archive/create/components/create-archive-form/fields/company-name-field.tsx
@@ -1,3 +1,5 @@
+import { HTMLAttributes } from 'react'
+
 import {
   FormControl,
   FormField,
@@ -6,7 +8,7 @@ import {
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes } from 'react'
+
 import { useCreateArchiveFormContext } from '../../../hooks/use-create-archive-form'
 interface CompanyNameFieldProps extends HTMLAttributes<HTMLDivElement> {}
 

--- a/src/app/(routes)/archive/create/components/create-archive-form/fields/content-field.tsx
+++ b/src/app/(routes)/archive/create/components/create-archive-form/fields/content-field.tsx
@@ -1,3 +1,5 @@
+import { HTMLAttributes } from 'react'
+
 import {
   FormControl,
   FormField,
@@ -6,7 +8,7 @@ import {
 } from '@/components/ui/form'
 import { Textarea } from '@/components/ui/textarea'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes } from 'react'
+
 import { useCreateArchiveFormContext } from '../../../hooks/use-create-archive-form'
 interface ContentFieldProps extends HTMLAttributes<HTMLDivElement> {}
 

--- a/src/app/(routes)/archive/create/components/create-archive-form/fields/title-field.tsx
+++ b/src/app/(routes)/archive/create/components/create-archive-form/fields/title-field.tsx
@@ -1,3 +1,5 @@
+import { HTMLAttributes } from 'react'
+
 import {
   FormControl,
   FormField,
@@ -6,7 +8,7 @@ import {
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes } from 'react'
+
 import { useCreateArchiveFormContext } from '../../../hooks/use-create-archive-form'
 interface TitleFieldProps extends HTMLAttributes<HTMLDivElement> {}
 

--- a/src/app/(routes)/archive/create/components/create-archive-form/form-action/index.tsx
+++ b/src/app/(routes)/archive/create/components/create-archive-form/form-action/index.tsx
@@ -1,7 +1,9 @@
+import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import Image from 'next/image'
-import { HTMLAttributes } from 'react'
+
 import { useCreateArchiveFormContext } from '../../../hooks/use-create-archive-form'
 interface FormActionProps extends HTMLAttributes<HTMLDivElement> {}
 

--- a/src/app/(routes)/archive/create/components/create-archive-form/heading/index.tsx
+++ b/src/app/(routes)/archive/create/components/create-archive-form/heading/index.tsx
@@ -1,6 +1,7 @@
-import { cn } from '@/lib/utils'
-import Image from 'next/image'
 import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
 interface HeadingProps extends HTMLAttributes<HeadingProps> {}
 
 export const Heading = ({ className, ...props }: HeadingProps) => {

--- a/src/app/(routes)/archive/create/components/create-archive-form/index.tsx
+++ b/src/app/(routes)/archive/create/components/create-archive-form/index.tsx
@@ -1,9 +1,11 @@
 'use client'
 
+import { HTMLAttributes } from 'react'
+
 import { Form } from '@/components/ui/form'
 import { useCreateArchive } from '@/entities/archives/hooks'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes } from 'react'
+
 import { useCreateArchiveFormContext } from '../../hooks/use-create-archive-form'
 import { ContentLength } from './content-length'
 import { CompanyNameField } from './fields/company-name-field'

--- a/src/app/(routes)/archive/create/components/form-status/index.tsx
+++ b/src/app/(routes)/archive/create/components/form-status/index.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { cn } from '@/lib/utils'
-import Image from 'next/image'
 import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
+
 import { useCreateArchiveFormContext } from '../../hooks/use-create-archive-form'
 import { IdleStatus } from './status/idle'
 import { ValidStatus } from './status/valid'

--- a/src/app/(routes)/archive/create/components/form-status/status/idle.tsx
+++ b/src/app/(routes)/archive/create/components/form-status/status/idle.tsx
@@ -1,6 +1,7 @@
-import { cn } from '@/lib/utils'
-import Image from 'next/image'
 import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
 interface InitialInterviewQuestionProps
   extends HTMLAttributes<HTMLDivElement> {}
 

--- a/src/app/(routes)/archive/create/components/form-status/status/valid.tsx
+++ b/src/app/(routes)/archive/create/components/form-status/status/valid.tsx
@@ -1,6 +1,7 @@
-import { cn } from '@/lib/utils'
-import Image from 'next/image'
 import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
 interface ValidInterviewQuestionProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const ValidStatus = ({

--- a/src/app/(routes)/archive/create/hooks/use-create-archive-form.tsx
+++ b/src/app/(routes)/archive/create/hooks/use-create-archive-form.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { ReactNode, createContext, useContext } from 'react'
+import { createContext, ReactNode, useContext } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 
 import {
   CreateArchiveFormData,
   createArchiveSchema,
 } from '@/config/validations/create-archive'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { useForm } from 'react-hook-form'
 
 const CreateArchiveFormContext = createContext<ReturnType<
   typeof useCreateArchiveForm

--- a/src/app/(routes)/practice/(dashboard)/components/current-status/index.tsx
+++ b/src/app/(routes)/practice/(dashboard)/components/current-status/index.tsx
@@ -1,11 +1,12 @@
+import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+
 import { ResultCard } from '@/components/cards/result-card'
 import { SmileAnimation } from '@/components/lotties/smile-animation'
 import { ThinkingAnimation } from '@/components/lotties/thinking-animation'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import Image from 'next/image'
-import Link from 'next/link'
-import { HTMLAttributes } from 'react'
 interface CurrentStatusProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const CurrentStatus = ({ className, ...props }: CurrentStatusProps) => {

--- a/src/app/(routes)/practice/(dashboard)/components/latest-practice/index.tsx
+++ b/src/app/(routes)/practice/(dashboard)/components/latest-practice/index.tsx
@@ -1,7 +1,8 @@
+import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
 import { DashboardQuestionCard } from '@/components/cards/dashboard-question-card'
 import { cn } from '@/lib/utils'
-import Image from 'next/image'
-import { HTMLAttributes } from 'react'
 interface LatestPracticeProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const LatestPractice = ({

--- a/src/app/(routes)/practice/(dashboard)/components/status-chart/index.tsx
+++ b/src/app/(routes)/practice/(dashboard)/components/status-chart/index.tsx
@@ -1,9 +1,10 @@
 'use client'
 
+import { HTMLAttributes, useState } from 'react'
+import Image from 'next/image'
+
 import { PracticeStatusChart } from '@/entities/dashboard/components/practice-status-chart'
 import { cn } from '@/lib/utils'
-import Image from 'next/image'
-import { HTMLAttributes, useState } from 'react'
 interface StatusChartProps extends HTMLAttributes<HTMLDivElement> {}
 
 const randomNum = (min: number, max: number) => {

--- a/src/app/(routes)/practice/ing/answer-button.tsx
+++ b/src/app/(routes)/practice/ing/answer-button.tsx
@@ -1,7 +1,9 @@
+import { HTMLAttributes } from 'react'
+import { motion } from 'framer-motion'
+
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import { motion } from 'framer-motion'
-import { HTMLAttributes } from 'react'
+
 import { Question } from './page'
 interface AnswerButtonProps extends HTMLAttributes<HTMLDivElement> {
   questions: Question[]

--- a/src/app/(routes)/practice/ing/ask-card.tsx
+++ b/src/app/(routes)/practice/ing/ask-card.tsx
@@ -1,6 +1,8 @@
-import { cn } from '@/lib/utils'
-import Image from 'next/image'
 import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
+
 import { Question } from './page'
 interface AskCardProps extends HTMLAttributes<HTMLDivElement> {
   question: Question

--- a/src/app/(routes)/practice/ing/hint-card.tsx
+++ b/src/app/(routes)/practice/ing/hint-card.tsx
@@ -1,7 +1,8 @@
+import { HTMLAttributes } from 'react'
+import { ChevronDown } from 'lucide-react'
+
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
-import { ChevronDown } from 'lucide-react'
-import { HTMLAttributes } from 'react'
 interface HintCardProps extends HTMLAttributes<HTMLDivElement> {
   showHint: boolean
   setShowHint: (showHint: boolean) => void

--- a/src/app/(routes)/practice/ing/page.tsx
+++ b/src/app/(routes)/practice/ing/page.tsx
@@ -1,12 +1,14 @@
 'use client'
 
+import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { AnimatePresence, motion } from 'framer-motion'
+import { LottieRefCurrentProps } from 'lottie-react'
+
 import { SmileAnimation } from '@/components/lotties/smile-animation'
 import { ThinkingAnimation } from '@/components/lotties/thinking-animation'
 import { cn } from '@/lib/utils'
-import { AnimatePresence, motion } from 'framer-motion'
-import { LottieRefCurrentProps } from 'lottie-react'
-import { useRouter } from 'next/navigation'
-import { useEffect, useRef, useState } from 'react'
+
 import { AnswerButton } from './answer-button'
 import { AskCard } from './ask-card'
 import { HintCard } from './hint-card'

--- a/src/app/(routes)/practice/result/page.tsx
+++ b/src/app/(routes)/practice/result/page.tsx
@@ -1,12 +1,13 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { ChevronRight } from 'lucide-react'
+
 import { ResultCard } from '@/components/cards/result-card'
 import { ConfettiAnimation } from '@/components/lotties/confetti-animation'
 import { SmileAnimation } from '@/components/lotties/smile-animation'
 import { ThinkingAnimation } from '@/components/lotties/thinking-animation'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { ChevronRight } from 'lucide-react'
-import Image from 'next/image'
-import Link from 'next/link'
 
 const Page = async () => {
   return (

--- a/src/app/api/auth/[...nextauth]/auth.ts
+++ b/src/app/api/auth/[...nextauth]/auth.ts
@@ -1,10 +1,11 @@
+import NextAuth, { Account, DefaultSession } from 'next-auth'
+import { JWT } from 'next-auth/jwt'
+import Google from 'next-auth/providers/google'
+
 import { signInAction } from '@/entities/auth/actions/sign-in-action'
 import { AuthDTO } from '@/entities/auth/types'
 import { getUserAction } from '@/entities/users/actions/get-user-action'
 import { UserDTO } from '@/entities/users/types'
-import NextAuth, { Account, DefaultSession } from 'next-auth'
-import { JWT } from 'next-auth/jwt'
-import Google from 'next-auth/providers/google'
 
 declare module 'next-auth' {
   interface Session {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,10 @@ import type { Metadata } from 'next'
 
 import { Header } from '@/components/layouts/header'
 import { pretendard } from '@/lib/fonts'
-import './globals.css'
+
 import { Providers } from './providers'
+
+import './globals.css'
 
 export const metadata: Metadata = {
   title: 'SulSul',

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,11 +1,12 @@
 'use client'
-import { Toaster } from '@/components/ui/sonner'
-import { getQueryClient } from '@/lib/tanstack-query/client'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { PropsWithChildren } from 'react'
 import { Session } from 'next-auth'
 import { SessionProvider } from 'next-auth/react'
-import { PropsWithChildren } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+
+import { Toaster } from '@/components/ui/sonner'
+import { getQueryClient } from '@/lib/tanstack-query/client'
 
 interface ProvidersProps extends PropsWithChildren {
   session?: Session

--- a/src/components/__design__/colors.stories.tsx
+++ b/src/components/__design__/colors.stories.tsx
@@ -1,5 +1,6 @@
-import { tailwindTheme } from '@/lib/utils'
 import type { StoryObj } from '@storybook/react'
+
+import { tailwindTheme } from '@/lib/utils'
 
 const colors = tailwindTheme.colors
 

--- a/src/components/auth/auth-loading.tsx
+++ b/src/components/auth/auth-loading.tsx
@@ -1,6 +1,6 @@
 'use client'
-import { useSession } from 'next-auth/react'
 import { PropsWithChildren } from 'react'
+import { useSession } from 'next-auth/react'
 interface AuthLoadingProps extends PropsWithChildren {}
 
 export const AuthLoading = ({ children }: AuthLoadingProps) => {

--- a/src/components/auth/auth-signed-in.tsx
+++ b/src/components/auth/auth-signed-in.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useSession } from 'next-auth/react'
 import { PropsWithChildren } from 'react'
+import { useSession } from 'next-auth/react'
 interface AuthSignedInProps extends PropsWithChildren {}
 
 export const AuthSignedIn = ({ children }: AuthSignedInProps) => {

--- a/src/components/auth/auth-signed-out.tsx
+++ b/src/components/auth/auth-signed-out.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useSession } from 'next-auth/react'
 import { PropsWithChildren } from 'react'
+import { useSession } from 'next-auth/react'
 interface AuthSignedOutProps extends PropsWithChildren {}
 
 export const AuthSignedOut = ({ children }: AuthSignedOutProps) => {

--- a/src/components/cards/dashboard-question-card.tsx
+++ b/src/components/cards/dashboard-question-card.tsx
@@ -1,5 +1,7 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
+
 import { Button } from '../ui/button'
 interface DashboardQuestionCardProps extends HTMLAttributes<HTMLDivElement> {}
 

--- a/src/components/cards/result-card.tsx
+++ b/src/components/cards/result-card.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface ResultCardProps extends HTMLAttributes<HTMLDivElement> {
   icon?: React.ReactNode
   result: React.ReactNode

--- a/src/components/cards/user-answer.tsx
+++ b/src/components/cards/user-answer.tsx
@@ -1,6 +1,8 @@
 'use client'
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
+
 import { Button } from '../ui/button'
 interface UserAnswerProps extends HTMLAttributes<HTMLDivElement> {
   data: string

--- a/src/components/layouts/footer.tsx
+++ b/src/components/layouts/footer.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface FooterProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const Footer = ({ className, ...props }: FooterProps) => {

--- a/src/components/layouts/header/desktop-header/header-animation.tsx
+++ b/src/components/layouts/header/desktop-header/header-animation.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { cn } from '@/lib/utils'
+import { HTMLAttributes, useRef } from 'react'
+import { usePathname } from 'next/navigation'
 import { useGSAP } from '@gsap/react'
 import gsap from 'gsap'
 import { ScrollTrigger } from 'gsap/all'
-import { usePathname } from 'next/navigation'
-import { HTMLAttributes, useRef } from 'react'
+
+import { cn } from '@/lib/utils'
 interface HeaderAnimationProps extends HTMLAttributes<HTMLDivElement> {}
 
 gsap.registerPlugin(ScrollTrigger)

--- a/src/components/layouts/header/desktop-header/header-navigation.tsx
+++ b/src/components/layouts/header/desktop-header/header-navigation.tsx
@@ -1,8 +1,9 @@
-import { DesktopHeaderLinks } from '@/config/constants/navigation-links'
-import { cn } from '@/lib/utils'
+import { HTMLAttributes } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { HTMLAttributes } from 'react'
+
+import { DesktopHeaderLinks } from '@/config/constants/navigation-links'
+import { cn } from '@/lib/utils'
 interface HeaderNavigationProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const HeaderNavigation = ({

--- a/src/components/layouts/header/desktop-header/index.tsx
+++ b/src/components/layouts/header/desktop-header/index.tsx
@@ -1,8 +1,11 @@
+import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { signIn, signOut } from 'next-auth/react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+
 import { Logo } from '@/components/shared/logo'
 import { Button } from '@/components/ui/button'
-import { APP_ROUTES } from '@/config/constants/app-routes'
-import { cn } from '@/lib/utils'
-
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -11,12 +14,10 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { APP_ROUTES } from '@/config/constants/app-routes'
 import { useCurrentUser } from '@/entities/users/hooks'
-import { ChevronDown, ChevronRight } from 'lucide-react'
-import { signIn, signOut } from 'next-auth/react'
-import Image from 'next/image'
-import Link from 'next/link'
-import { HTMLAttributes } from 'react'
+import { cn } from '@/lib/utils'
+
 import { HeaderNavigation } from './header-navigation'
 interface DesktopHeaderProps extends HTMLAttributes<HTMLDivElement> {}
 

--- a/src/components/layouts/header/index.tsx
+++ b/src/components/layouts/header/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { HTMLAttributes } from 'react'
+
 import { DesktopHeader } from './desktop-header'
 import { HeaderAnimation } from './desktop-header/header-animation'
 import { MobileHeader } from './mobile-header'

--- a/src/components/layouts/header/mobile-header/index.tsx
+++ b/src/components/layouts/header/mobile-header/index.tsx
@@ -1,5 +1,12 @@
 'use client'
 
+import { HTMLAttributes } from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { ChevronRight, MenuIcon } from 'lucide-react'
+
+import { AuthSignedOut } from '@/components/auth/auth-signed-out'
+import { Logo } from '@/components/shared/logo'
 import {
   Sheet,
   SheetClose,
@@ -8,15 +15,8 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet'
-
-import { AuthSignedOut } from '@/components/auth/auth-signed-out'
-import { Logo } from '@/components/shared/logo'
 import { MobileHeaderLinks } from '@/config/constants/navigation-links'
 import { cn } from '@/lib/utils'
-import { ChevronRight, MenuIcon } from 'lucide-react'
-import Link from 'next/link'
-import { usePathname } from 'next/navigation'
-import { HTMLAttributes } from 'react'
 interface MobileHeaderProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const MobileHeader = ({ className, ...props }: MobileHeaderProps) => {

--- a/src/components/lotties/check-animation.tsx
+++ b/src/components/lotties/check-animation.tsx
@@ -1,9 +1,10 @@
 'use client'
 
+import dynamic from 'next/dynamic'
+import { LottieComponentProps } from 'lottie-react'
+
 import animationData from '@/components/lotties/assets/btn-check.json'
 import { cn } from '@/lib/utils'
-import { LottieComponentProps } from 'lottie-react'
-import dynamic from 'next/dynamic'
 
 const Lottie = dynamic(() => import('lottie-react'), {
   ssr: false,

--- a/src/components/lotties/confetti-animation.tsx
+++ b/src/components/lotties/confetti-animation.tsx
@@ -1,8 +1,9 @@
 'use client'
+import dynamic from 'next/dynamic'
+import { LottieComponentProps } from 'lottie-react'
+
 import animationData from '@/components/lotties/assets/confetti.json'
 import { cn } from '@/lib/utils'
-import { LottieComponentProps } from 'lottie-react'
-import dynamic from 'next/dynamic'
 
 const Lottie = dynamic(() => import('lottie-react'), {
   ssr: false,

--- a/src/components/lotties/smile-animation.tsx
+++ b/src/components/lotties/smile-animation.tsx
@@ -1,8 +1,9 @@
 'use client'
+import dynamic from 'next/dynamic'
+import { LottieComponentProps } from 'lottie-react'
+
 import animationData from '@/components/lotties/assets/face-smile.json'
 import { cn } from '@/lib/utils'
-import { LottieComponentProps } from 'lottie-react'
-import dynamic from 'next/dynamic'
 
 const Lottie = dynamic(() => import('lottie-react'), {
   ssr: false,

--- a/src/components/lotties/thinking-animation.tsx
+++ b/src/components/lotties/thinking-animation.tsx
@@ -1,9 +1,10 @@
 'use client'
 
+import dynamic from 'next/dynamic'
+import { LottieComponentProps } from 'lottie-react'
+
 import animationData from '@/components/lotties/assets/face-thinking.json'
 import { cn } from '@/lib/utils'
-import { LottieComponentProps } from 'lottie-react'
-import dynamic from 'next/dynamic'
 
 const Lottie = dynamic(() => import('lottie-react'), {
   ssr: false,

--- a/src/components/shared/loader.tsx
+++ b/src/components/shared/loader.tsx
@@ -1,7 +1,9 @@
 'use client'
-import { cn } from '@/lib/utils'
-import Image from 'next/image'
 import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
+
 import './loader.css'
 interface LoaderProps extends HTMLAttributes<HTMLDivElement> {}
 

--- a/src/components/shared/logo.tsx
+++ b/src/components/shared/logo.tsx
@@ -1,6 +1,7 @@
-import { cn } from '@/lib/utils'
-import Image from 'next/image'
 import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
 interface LogoProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const Logo = ({ className, ...props }: LogoProps) => {

--- a/src/components/shared/video.tsx
+++ b/src/components/shared/video.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { cn } from '@/lib/utils'
 import { ForwardedRef, MediaHTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 export interface VideoProps extends MediaHTMLAttributes<HTMLVideoElement> {
   videoRef?: ForwardedRef<HTMLVideoElement>
 }

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,8 +1,8 @@
 'use client'
 
+import * as React from 'react'
 import * as AccordionPrimitive from '@radix-ui/react-accordion'
 import { ChevronDown } from 'lucide-react'
-import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
 import * as React from 'react'
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
 
 import { buttonVariants } from '@/components/ui/button'
 import { cn } from '@/lib/utils'

--- a/src/components/ui/badge/badge.stories.tsx
+++ b/src/components/ui/badge/badge.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
+
 import { Badge } from '.'
 
 const meta: Meta<typeof Badge> = {

--- a/src/components/ui/badge/index.tsx
+++ b/src/components/ui/badge/index.tsx
@@ -1,5 +1,5 @@
-import { cva, type VariantProps } from 'class-variance-authority'
 import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/button/button.stories.tsx
+++ b/src/components/ui/button/button.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
+
 import { Button } from '.'
 
 const meta: Meta<typeof Button> = {

--- a/src/components/ui/button/index.tsx
+++ b/src/components/ui/button/index.tsx
@@ -1,6 +1,6 @@
+import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
-import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/checkbox/checkbox.stories.tsx
+++ b/src/components/ui/checkbox/checkbox.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
+
 import { Checkbox } from '.'
 
 const meta: Meta<typeof Checkbox> = {

--- a/src/components/ui/checkbox/index.tsx
+++ b/src/components/ui/checkbox/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
+import * as React from 'react'
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
 import { Check } from 'lucide-react'
-import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,8 +1,8 @@
 'use client'
 
+import * as React from 'react'
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
 import { Check, ChevronRight, Circle } from 'lucide-react'
-import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react'
-import * as LabelPrimitive from '@radix-ui/react-label'
-import { Slot } from '@radix-ui/react-slot'
 import {
   Controller,
   ControllerProps,
@@ -9,9 +7,11 @@ import {
   FormProvider,
   useFormContext,
 } from 'react-hook-form'
+import * as LabelPrimitive from '@radix-ui/react-label'
+import { Slot } from '@radix-ui/react-slot'
 
-import { cn } from '@/lib/utils'
 import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
 
 const Form = FormProvider
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,9 +1,9 @@
 'use client'
 
+import * as React from 'react'
 import * as SheetPrimitive from '@radix-ui/react-dialog'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { X } from 'lucide-react'
-import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/tabs/index.tsx
+++ b/src/components/ui/tabs/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import * as TabsPrimitive from '@radix-ui/react-tabs'
 import * as React from 'react'
+import * as TabsPrimitive from '@radix-ui/react-tabs'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import * as TooltipPrimitive from '@radix-ui/react-tooltip'
 import * as React from 'react'
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
 
 import { cn } from '@/lib/utils'
 

--- a/src/entities/archives/components/archive-card/archive-card-menu.tsx
+++ b/src/entities/archives/components/archive-card/archive-card-menu.tsx
@@ -1,14 +1,16 @@
 'use client'
 
+import { forwardRef } from 'react'
+import Image from 'next/image'
+import { DropdownMenuProps } from '@radix-ui/react-dropdown-menu'
+
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { DropdownMenuProps } from '@radix-ui/react-dropdown-menu'
-import Image from 'next/image'
-import { forwardRef } from 'react'
+
 import { ArchiveDeleteButton } from './archive-delete-button'
 interface ArchiveCardMenuProps extends DropdownMenuProps {
   archiveId: number

--- a/src/entities/archives/components/archive-card/archive-card.stories.tsx
+++ b/src/entities/archives/components/archive-card/archive-card.stories.tsx
@@ -1,6 +1,8 @@
-import * as actions from '@/entities/archives/actions'
 import type { Meta, StoryObj } from '@storybook/react'
 import { createMock } from 'storybook-addon-module-mock'
+
+import * as actions from '@/entities/archives/actions'
+
 import { mockArchiveListItemDTO } from '../../fixtures'
 import { ArchiveCard } from './'
 

--- a/src/entities/archives/components/archive-card/archive-delete-button.tsx
+++ b/src/entities/archives/components/archive-card/archive-delete-button.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import React, { forwardRef } from 'react'
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,7 +15,6 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { useDeleteArchive } from '@/entities/archives/hooks'
-import React, { forwardRef } from 'react'
 
 interface ArchiveDeleteButtonProps {
   archiveId: number

--- a/src/entities/archives/components/archive-card/index.tsx
+++ b/src/entities/archives/components/archive-card/index.tsx
@@ -1,9 +1,11 @@
 'use client'
 
+import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
 import { ArchiveStatus } from '@/entities/types'
 import { cn } from '@/lib/utils'
-import Image from 'next/image'
-import { HTMLAttributes } from 'react'
+
 import { ArchiveCardMenu } from './archive-card-menu'
 interface ArchiveCardProps extends HTMLAttributes<HTMLDivElement> {
   status: ArchiveStatus

--- a/src/entities/archives/components/archive-content/action-buttons/index.tsx
+++ b/src/entities/archives/components/archive-content/action-buttons/index.tsx
@@ -1,12 +1,13 @@
 'use client'
 
+import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+import { useRouter } from 'next/navigation'
+
 import { Button } from '@/components/ui/button'
 import { APP_ROUTES } from '@/config/constants/app-routes'
 import { ArchiveFeedbackStatus } from '@/entities/types'
 import { cn } from '@/lib/utils'
-import Image from 'next/image'
-import { useRouter } from 'next/navigation'
-import { HTMLAttributes } from 'react'
 interface ActionButtonsProps extends HTMLAttributes<HTMLDivElement> {
   status: ArchiveFeedbackStatus
 }

--- a/src/entities/archives/components/archive-content/index.tsx
+++ b/src/entities/archives/components/archive-content/index.tsx
@@ -1,7 +1,9 @@
+import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
 import { ArchiveStatus } from '@/entities/types'
 import { cn } from '@/lib/utils'
-import Image from 'next/image'
-import { HTMLAttributes } from 'react'
+
 import { ActionButtons } from './action-buttons'
 
 interface ArchiveContentProps extends HTMLAttributes<HTMLDivElement> {

--- a/src/entities/archives/components/feedback-section-complete/feedback-section-complete.stories.tsx
+++ b/src/entities/archives/components/feedback-section-complete/feedback-section-complete.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { faker } from '@/lib/faker'
+
 import { FeedbackSectionComplete } from './index'
 
 const meta = {

--- a/src/entities/archives/components/feedback-section-complete/index.tsx
+++ b/src/entities/archives/components/feedback-section-complete/index.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface FeedbackSectionCompleteProps extends HTMLAttributes<HTMLDivElement> {
   goodFeedback: string
   badFeedback: string

--- a/src/entities/archives/components/feedback-section-idle/feedback-section-idle.stories.tsx
+++ b/src/entities/archives/components/feedback-section-idle/feedback-section-idle.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
 import { fn } from '@storybook/test'
+
 import { FeedbackSectionIdle } from './index'
 
 const meta = {

--- a/src/entities/archives/components/feedback-section-idle/index.tsx
+++ b/src/entities/archives/components/feedback-section-idle/index.tsx
@@ -1,6 +1,7 @@
+import { HTMLAttributes } from 'react'
+
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes } from 'react'
 interface FeedbackSectionIdleProps extends HTMLAttributes<HTMLDivElement> {
   handleCreateFeedback: () => void
 }

--- a/src/entities/archives/components/feedback-section-pending/index.tsx
+++ b/src/entities/archives/components/feedback-section-pending/index.tsx
@@ -1,6 +1,7 @@
-import { cn } from '@/lib/utils'
-import { Loader2 } from 'lucide-react'
 import { HTMLAttributes } from 'react'
+import { Loader2 } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
 interface FeedbackSectionPendingProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const FeedbackSectionPending = ({

--- a/src/entities/archives/components/interview-questions/index.tsx
+++ b/src/entities/archives/components/interview-questions/index.tsx
@@ -1,9 +1,11 @@
 'use client'
 
+import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
 import { ArchiveDetailDTO } from '@/entities/types'
 import { cn } from '@/lib/utils'
-import Image from 'next/image'
-import { HTMLAttributes } from 'react'
+
 import { LoadedStatus } from './status/loaded'
 import { PendingStatus } from './status/pending'
 interface InterviewQuestionsProps extends HTMLAttributes<HTMLDivElement> {

--- a/src/entities/archives/components/interview-questions/status/loaded.tsx
+++ b/src/entities/archives/components/interview-questions/status/loaded.tsx
@@ -1,6 +1,8 @@
+import { HTMLAttributes } from 'react'
+
 import { ArchiveQuestionItem } from '@/entities/types'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes } from 'react'
+
 import { QuestionCard } from '../../question-card'
 interface LoadedInterviewQuestionProps extends HTMLAttributes<HTMLDivElement> {
   data: ArchiveQuestionItem[]

--- a/src/entities/archives/components/interview-questions/status/pending.tsx
+++ b/src/entities/archives/components/interview-questions/status/pending.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface PendingInterviewQuestionProps
   extends HTMLAttributes<HTMLDivElement> {}
 

--- a/src/entities/archives/components/keyword-section/index.tsx
+++ b/src/entities/archives/components/keyword-section/index.tsx
@@ -1,3 +1,6 @@
+import { HTMLAttributes } from 'react'
+import { HelpCircle, PlusIcon, X } from 'lucide-react'
+
 import { Button } from '@/components/ui/button'
 import {
   Tooltip,
@@ -7,8 +10,6 @@ import {
 } from '@/components/ui/tooltip'
 import { ArchiveKeyword } from '@/entities/types'
 import { cn } from '@/lib/utils'
-import { HelpCircle, PlusIcon, X } from 'lucide-react'
-import { HTMLAttributes } from 'react'
 interface KeywordSectionProps extends HTMLAttributes<HTMLDivElement> {
   keywords: ArchiveKeyword[]
   onDeleteKeyword: (keyword: ArchiveKeyword) => void

--- a/src/entities/archives/components/keyword-section/keyword-section.stories.tsx
+++ b/src/entities/archives/components/keyword-section/keyword-section.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
 import { fn } from '@storybook/test'
+
 import { mockArchiveKeyword } from '../../fixtures'
 import { KeywordSection } from './index'
 

--- a/src/entities/archives/components/question-answer-form/index.tsx
+++ b/src/entities/archives/components/question-answer-form/index.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { HTMLAttributes } from 'react'
+
 import { Button } from '@/components/ui/button'
 import {
   Form,
@@ -10,7 +12,7 @@ import {
 } from '@/components/ui/form'
 import { Textarea } from '@/components/ui/textarea'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes } from 'react'
+
 import {
   QuestionAnswerFormValues,
   useQuestionAnswerForm,

--- a/src/entities/archives/components/question-answer-form/question-answer-form.stories.tsx
+++ b/src/entities/archives/components/question-answer-form/question-answer-form.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { fn } from '@storybook/test'
+
 import { QuestionAnswerForm } from './index'
 
 const meta = {

--- a/src/entities/archives/components/question-answer/index.tsx
+++ b/src/entities/archives/components/question-answer/index.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
-import { ArchiveKeyword } from '@/entities/types'
-import { cn } from '@/lib/utils'
-import Image from 'next/image'
 import { HTMLAttributes } from 'react'
 import { HighlightMenu } from 'react-highlight-menu'
 import Highlighter from 'react-highlight-words'
+import Image from 'next/image'
+
+import { Button } from '@/components/ui/button'
+import { ArchiveKeyword } from '@/entities/types'
+import { cn } from '@/lib/utils'
 interface QuestionAnswerProps extends HTMLAttributes<HTMLDivElement> {
   answer: string
   onCreateKeywordNote: (keyword: string) => void

--- a/src/entities/archives/components/question-answer/question-answer.stories.tsx
+++ b/src/entities/archives/components/question-answer/question-answer.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { fn } from '@storybook/test'
+
 import { mockArchiveKeyword } from '../../fixtures'
 import { QuestionAnswer } from './index'
 

--- a/src/entities/archives/components/question-card/card-body.tsx
+++ b/src/entities/archives/components/question-card/card-body.tsx
@@ -1,6 +1,8 @@
+import { HTMLAttributes } from 'react'
+
 import { ArchiveFeedback, ArchiveQuestionItem } from '@/entities/types'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes } from 'react'
+
 import { FeedbackSectionComplete } from '../feedback-section-complete'
 import { FeedbackSectionIdle } from '../feedback-section-idle'
 import { KeywordSection } from '../keyword-section'

--- a/src/entities/archives/components/question-card/card-header.tsx
+++ b/src/entities/archives/components/question-card/card-header.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface CardHeaderProps extends HTMLAttributes<HTMLDivElement> {
   content: string
 }

--- a/src/entities/archives/components/question-card/index.tsx
+++ b/src/entities/archives/components/question-card/index.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
 
 import {
@@ -10,6 +9,8 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion'
 import { ArchiveQuestionItem } from '@/entities/types'
+import { cn } from '@/lib/utils'
+
 import { mockArchiveFeedback } from '../../fixtures'
 import { CardBody } from './card-body'
 import { CardHeader } from './card-header'

--- a/src/entities/archives/hooks/use-archive.ts
+++ b/src/entities/archives/hooks/use-archive.ts
@@ -1,5 +1,6 @@
-import { getArchiveDetailAction } from '@/entities/archives/actions'
 import { useQuery } from '@tanstack/react-query'
+
+import { getArchiveDetailAction } from '@/entities/archives/actions'
 export const useArchive = (id: number) => {
   const result = useQuery({
     queryKey: ['archive', { id }],

--- a/src/entities/archives/hooks/use-archives.ts
+++ b/src/entities/archives/hooks/use-archives.ts
@@ -1,7 +1,8 @@
 'use client'
 
-import { getArchiveListAction } from '@/entities/archives/actions'
 import { queryOptions, useQuery } from '@tanstack/react-query'
+
+import { getArchiveListAction } from '@/entities/archives/actions'
 
 export const ArchiveListQueryOptions = queryOptions({
   queryKey: ['archives', 'list'],

--- a/src/entities/archives/hooks/use-create-archive.ts
+++ b/src/entities/archives/hooks/use-create-archive.ts
@@ -1,8 +1,10 @@
+import { useRouter } from 'next/navigation'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
 import { CreateArchiveFormData } from '@/config/validations/create-archive'
 import { createArchiveAction } from '@/entities/archives/actions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
-import { toast } from 'sonner'
+
 import { ArchiveListQueryOptions } from './use-archives'
 
 export const useCreateArchive = () => {

--- a/src/entities/archives/hooks/use-delete-archive.ts
+++ b/src/entities/archives/hooks/use-delete-archive.ts
@@ -1,6 +1,8 @@
-import { deleteArchiveAction } from '@/entities/archives/actions'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
+
+import { deleteArchiveAction } from '@/entities/archives/actions'
+
 import { ArchiveListQueryOptions } from './use-archives'
 
 export const useDeleteArchive = () => {

--- a/src/entities/archives/hooks/use-question-answer-form.ts
+++ b/src/entities/archives/hooks/use-question-answer-form.ts
@@ -1,5 +1,5 @@
-import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 
 export const questionAnswerFormSchema = z.object({

--- a/src/entities/archives/views/archive-detail-view/index.tsx
+++ b/src/entities/archives/views/archive-detail-view/index.tsx
@@ -1,9 +1,11 @@
 'use client'
 
+import { redirect } from 'next/navigation'
+
 import { Loader } from '@/components/shared/loader'
 import { InterviewQuestions } from '@/entities/archives/components/interview-questions'
 import { useArchive } from '@/entities/archives/hooks'
-import { redirect } from 'next/navigation'
+
 import { ArchiveContent } from '../../components/archive-content'
 
 interface ArchiveDetailViewProps {

--- a/src/entities/archives/views/archive-list-view/archive-list-view.stories.tsx
+++ b/src/entities/archives/views/archive-list-view/archive-list-view.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { createMock } from 'storybook-addon-module-mock'
 
 import Layout from '@/app/(routes)/layout'
 import * as actions from '@/entities/archives/actions'
-import { createMock } from 'storybook-addon-module-mock'
+
 import { mockGetArchiveListAction } from '../../fixtures'
 import { ArchiveListView } from './'
 

--- a/src/entities/archives/views/archive-list-view/index.tsx
+++ b/src/entities/archives/views/archive-list-view/index.tsx
@@ -1,7 +1,9 @@
-import { APP_ROUTES } from '@/config/constants/app-routes'
+import { HTMLAttributes } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { HTMLAttributes } from 'react'
+
+import { APP_ROUTES } from '@/config/constants/app-routes'
+
 import { ArchiveCard } from '../../components/archive-card'
 import { useArchives } from '../../hooks'
 interface ArchiveListViewProps extends HTMLAttributes<HTMLDivElement> {}

--- a/src/entities/auth/actions/sign-in-action.ts
+++ b/src/entities/auth/actions/sign-in-action.ts
@@ -2,6 +2,7 @@
 
 import { API_ENDPOINT } from '@/lib/backend-api/api-end-point'
 import { backendApi } from '@/lib/backend-api/client'
+
 import { AuthDTO } from '../types'
 
 export interface SignInActionParams {

--- a/src/entities/auth/views/sign-in-error-view/index.tsx
+++ b/src/entities/auth/views/sign-in-error-view/index.tsx
@@ -1,10 +1,11 @@
 'use client'
 
+import { HTMLAttributes } from 'react'
+import { redirect } from 'next/navigation'
+
 import { APP_ROUTES } from '@/config/constants/app-routes'
 import { useCurrentUser } from '@/entities/users/hooks'
 import { cn } from '@/lib/utils'
-import { redirect } from 'next/navigation'
-import { HTMLAttributes } from 'react'
 interface SignInErrorViewProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const SignInErrorView = ({

--- a/src/entities/auth/views/sign-in-error-view/sign-in-error-view.stories.tsx
+++ b/src/entities/auth/views/sign-in-error-view/sign-in-error-view.stories.tsx
@@ -1,7 +1,9 @@
-import * as actions from '@/entities/users/hooks'
 import type { Meta, StoryObj } from '@storybook/react'
 import { fn } from '@storybook/test'
 import { createMock } from 'storybook-addon-module-mock'
+
+import * as actions from '@/entities/users/hooks'
+
 import { SignInErrorView } from './index'
 
 const meta = {

--- a/src/entities/auth/views/sing-in-view/index.tsx
+++ b/src/entities/auth/views/sing-in-view/index.tsx
@@ -1,9 +1,10 @@
-import { Button } from '@/components/ui/button'
-import { cn } from '@/lib/utils'
-import { signIn } from 'next-auth/react'
+import { HTMLAttributes } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { HTMLAttributes } from 'react'
+import { signIn } from 'next-auth/react'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 interface SingInViewProps extends HTMLAttributes<HTMLDivElement> {
   callbackUrl: string
 }

--- a/src/entities/auth/views/sing-in-view/sign-in-view.stories.tsx
+++ b/src/entities/auth/views/sing-in-view/sign-in-view.stories.tsx
@@ -1,6 +1,7 @@
-import type { Meta, StoryObj } from '@storybook/react'
 import * as actions from 'next-auth/react'
+import type { Meta, StoryObj } from '@storybook/react'
 import { createMock } from 'storybook-addon-module-mock'
+
 import { SingInView } from './index'
 
 const meta = {

--- a/src/entities/dashboard/components/practice-archive-select/index.tsx
+++ b/src/entities/dashboard/components/practice-archive-select/index.tsx
@@ -1,9 +1,10 @@
+import { HTMLAttributes } from 'react'
+import { ChevronRightIcon } from 'lucide-react'
+
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Separator } from '@/components/ui/separator'
 import { cn } from '@/lib/utils'
-import { ChevronRightIcon } from 'lucide-react'
-import { HTMLAttributes } from 'react'
 interface PracticeArchiveSelectProps extends HTMLAttributes<HTMLDivElement> {
   data: PracticeArchiveSelectItemProps[]
   handleSelect?: (id: string) => void

--- a/src/entities/dashboard/components/practice-archive-select/practice-archive-select.stories.tsx
+++ b/src/entities/dashboard/components/practice-archive-select/practice-archive-select.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { fn } from '@storybook/test'
+
 import { PracticeArchiveSelect } from '.'
 
 const meta = {

--- a/src/entities/dashboard/components/practice-practiced-question-section-heading/index.tsx
+++ b/src/entities/dashboard/components/practice-practiced-question-section-heading/index.tsx
@@ -1,6 +1,7 @@
-import { cn } from '@/lib/utils'
-import Image from 'next/image'
 import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
 interface PracticePracticedQuestionSectionHeadingProps
   extends HTMLAttributes<HTMLDivElement> {}
 

--- a/src/entities/dashboard/components/practice-question-select/index.tsx
+++ b/src/entities/dashboard/components/practice-question-select/index.tsx
@@ -1,7 +1,8 @@
+import { HTMLAttributes } from 'react'
+
 import { Checkbox } from '@/components/ui/checkbox'
 import { Separator } from '@/components/ui/separator'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes } from 'react'
 interface PracticeQuestionSelectProps extends HTMLAttributes<HTMLDivElement> {
   data: PracticeQuestionSelectItemProps[]
   handleSelect?: (id: string) => void

--- a/src/entities/dashboard/components/practice-question-select/practice-question-select.stories.tsx
+++ b/src/entities/dashboard/components/practice-question-select/practice-question-select.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { fn } from '@storybook/test'
+
 import { PracticeQuestionSelect } from '.'
 
 const meta = {

--- a/src/entities/dashboard/components/practice-result-card/index.tsx
+++ b/src/entities/dashboard/components/practice-result-card/index.tsx
@@ -1,8 +1,9 @@
+import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
 import { SmileAnimation } from '@/components/lotties/smile-animation'
 import { ThinkingAnimation } from '@/components/lotties/thinking-animation'
 import { cn } from '@/lib/utils'
-import Image from 'next/image'
-import { HTMLAttributes } from 'react'
 interface PracticeResultCardProps extends HTMLAttributes<HTMLDivElement> {
   type: 'good' | 'bad' | 'time'
   value: string | number

--- a/src/entities/dashboard/components/practice-start-card/index.tsx
+++ b/src/entities/dashboard/components/practice-start-card/index.tsx
@@ -1,7 +1,8 @@
+import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import Image from 'next/image'
-import { HTMLAttributes } from 'react'
 interface PracticeStartCardProps extends HTMLAttributes<HTMLDivElement> {
   nickname: string
   handleStartPractice: () => void

--- a/src/entities/dashboard/components/practice-start-card/practice-start-card.stories.tsx
+++ b/src/entities/dashboard/components/practice-start-card/practice-start-card.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
 import { fn } from '@storybook/test'
+
 import { PracticeStartCard } from './index'
 
 const meta = {

--- a/src/entities/dashboard/components/practice-status-chart-section-heading/index.tsx
+++ b/src/entities/dashboard/components/practice-status-chart-section-heading/index.tsx
@@ -1,6 +1,7 @@
-import { cn } from '@/lib/utils'
-import Image from 'next/image'
 import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
 interface PracticeStatusChartSectionHeadingProps
   extends HTMLAttributes<HTMLDivElement> {}
 

--- a/src/entities/dashboard/components/practice-status-chart-tab/index.tsx
+++ b/src/entities/dashboard/components/practice-status-chart-tab/index.tsx
@@ -1,6 +1,8 @@
+import { HTMLAttributes } from 'react'
+
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes } from 'react'
+
 import { PracticeStatusChartTabType } from '../../types'
 interface PracticedQuestionTabProps extends HTMLAttributes<HTMLDivElement> {
   onTabChange?: (value: PracticeStatusChartTabType) => void

--- a/src/entities/dashboard/components/practice-status-chart-tab/practice-status-chart-tab.stories.tsx
+++ b/src/entities/dashboard/components/practice-status-chart-tab/practice-status-chart-tab.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
 import { fn } from '@storybook/test'
+
 import { PracticedQuestionTab } from './'
 
 const meta = {

--- a/src/entities/dashboard/components/practice-status-chart/index.tsx
+++ b/src/entities/dashboard/components/practice-status-chart/index.tsx
@@ -1,19 +1,20 @@
 'use client'
 
-import { cn, tailwindTheme } from '@/lib/utils'
-
+import { HTMLAttributes } from 'react'
 import {
   BarElement,
   CategoryScale,
-  ChartData,
   Chart as ChartJS,
+  ChartData,
   ChartOptions,
   Legend,
   LinearScale,
   Title,
   Tooltip,
 } from 'chart.js'
-import { HTMLAttributes } from 'react'
+
+import { cn, tailwindTheme } from '@/lib/utils'
+
 import { MonthlyChart } from './monthly'
 import { WeeklyChart } from './weekly'
 

--- a/src/entities/dashboard/components/practice-status-chart/monthly.tsx
+++ b/src/entities/dashboard/components/practice-status-chart/monthly.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { cn } from '@/lib/utils'
-
-import { Chart, ChartData, ChartOptions, Plugin } from 'chart.js'
 import { HTMLAttributes, useEffect } from 'react'
 import { Bar } from 'react-chartjs-2'
+import { Chart, ChartData, ChartOptions, Plugin } from 'chart.js'
+
+import { cn } from '@/lib/utils'
 
 interface MonthlyChartProps extends HTMLAttributes<HTMLDivElement> {
   options: ChartOptions<'bar'>

--- a/src/entities/dashboard/components/practice-status-chart/practice-status-chart.stories.tsx
+++ b/src/entities/dashboard/components/practice-status-chart/practice-status-chart.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
+
 import { PracticeStatusChart } from '.'
 
 const meta = {} satisfies Meta

--- a/src/entities/dashboard/components/practice-status-chart/weekly.tsx
+++ b/src/entities/dashboard/components/practice-status-chart/weekly.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { cn } from '@/lib/utils'
-
-import { Chart, ChartData, ChartOptions, Plugin } from 'chart.js'
 import { HTMLAttributes, useEffect } from 'react'
 import { Bar } from 'react-chartjs-2'
+import { Chart, ChartData, ChartOptions, Plugin } from 'chart.js'
+
+import { cn } from '@/lib/utils'
 
 const week = new Date().getDay()
 

--- a/src/entities/dashboard/components/practiced-question-card/index.tsx
+++ b/src/entities/dashboard/components/practiced-question-card/index.tsx
@@ -1,6 +1,7 @@
+import { HTMLAttributes } from 'react'
+
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes } from 'react'
 interface PracticedQuestionCardProps extends HTMLAttributes<HTMLDivElement> {
   question: string
   title: string

--- a/src/entities/dashboard/components/practiced-question-card/practiced-question-card.stories.tsx
+++ b/src/entities/dashboard/components/practiced-question-card/practiced-question-card.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
 import { fn } from '@storybook/test'
+
 import { PracticedQuestionCard } from './'
 
 const meta = {

--- a/src/entities/dashboard/components/practiced-question-tab/index.tsx
+++ b/src/entities/dashboard/components/practiced-question-tab/index.tsx
@@ -1,6 +1,8 @@
+import { HTMLAttributes } from 'react'
+
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { cn } from '@/lib/utils'
-import { HTMLAttributes } from 'react'
+
 import { PracticedQuestionTabType } from '../../types'
 
 interface PracticedQuestionTabProps extends HTMLAttributes<HTMLDivElement> {

--- a/src/entities/dashboard/components/practiced-question-tab/practiced-question-tab.stories.tsx
+++ b/src/entities/dashboard/components/practiced-question-tab/practiced-question-tab.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
 import { fn } from '@storybook/test'
+
 import { PracticedQuestionTab } from './'
 
 const meta = {

--- a/src/entities/users/actions/get-user-action.ts
+++ b/src/entities/users/actions/get-user-action.ts
@@ -1,5 +1,6 @@
 import { API_ENDPOINT } from '@/lib/backend-api/api-end-point'
 import { backendApi } from '@/lib/backend-api/client'
+
 import { UserDTO } from '../types'
 
 export interface GetUserActionParams {

--- a/src/entities/users/actions/update-user-action.ts
+++ b/src/entities/users/actions/update-user-action.ts
@@ -2,6 +2,7 @@
 
 import { API_ENDPOINT } from '@/lib/backend-api/api-end-point'
 import { backendApi } from '@/lib/backend-api/client'
+
 import { UserDTO } from '../types'
 
 export interface UpdateUserNicknameActionParams {

--- a/src/entities/users/components/drop-out/index.tsx
+++ b/src/entities/users/components/drop-out/index.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface DropOutProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const DropOut = ({ className, ...props }: DropOutProps) => {

--- a/src/entities/users/components/my-form/index.tsx
+++ b/src/entities/users/components/my-form/index.tsx
@@ -1,3 +1,6 @@
+import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+
 import { Button } from '@/components/ui/button'
 import {
   Form,
@@ -11,8 +14,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useCurrentUser } from '@/entities/users/hooks'
 import { cn } from '@/lib/utils'
-import Image from 'next/image'
-import { HTMLAttributes } from 'react'
+
 import { useMyForm } from '../../hooks/use-my-form'
 interface MyFormProps extends HTMLAttributes<HTMLDivElement> {}
 

--- a/src/entities/users/components/profile-image/index.tsx
+++ b/src/entities/users/components/profile-image/index.tsx
@@ -1,7 +1,8 @@
-import { cn } from '@/lib/utils'
-import { useSession } from 'next-auth/react'
-import Image from 'next/image'
 import { HTMLAttributes } from 'react'
+import Image from 'next/image'
+import { useSession } from 'next-auth/react'
+
+import { cn } from '@/lib/utils'
 interface ProfileImageProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const ProfileImage = ({ className, ...props }: ProfileImageProps) => {

--- a/src/entities/users/hooks/use-my-form.ts
+++ b/src/entities/users/hooks/use-my-form.ts
@@ -1,10 +1,12 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { toast } from 'sonner'
+
 import {
   MyFormData,
   myFormValidation,
 } from '@/config/validations/my-form-validation'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { useForm } from 'react-hook-form'
-import { toast } from 'sonner'
+
 import { useCurrentUser } from './use-current-user'
 import { useUpdateNickname } from './use-update-nickname'
 

--- a/src/entities/users/hooks/use-update-nickname.ts
+++ b/src/entities/users/hooks/use-update-nickname.ts
@@ -1,8 +1,9 @@
-import {
-  UpdateUserNicknameActionParams,
-  updateUserNicknameAction,
-} from '@/entities/users/actions'
 import { useMutation } from '@tanstack/react-query'
+
+import {
+  updateUserNicknameAction,
+  UpdateUserNicknameActionParams,
+} from '@/entities/users/actions'
 
 export const useUpdateNickname = () => {
   return useMutation({

--- a/src/entities/users/views/my-page-view/index.tsx
+++ b/src/entities/users/views/my-page-view/index.tsx
@@ -1,11 +1,13 @@
 'use client'
 
+import { Separator } from '@radix-ui/react-dropdown-menu'
+import { Loader } from 'lucide-react'
+
 import { AuthLoading } from '@/components/auth/auth-loading'
 import { AuthSignedIn } from '@/components/auth/auth-signed-in'
 import { DropOut } from '@/entities/users/components/drop-out'
 import { ProfileImage } from '@/entities/users/components/profile-image'
-import { Separator } from '@radix-ui/react-dropdown-menu'
-import { Loader } from 'lucide-react'
+
 import { MyForm } from '../../components/my-form'
 
 export const MyPageView = () => {

--- a/src/entities/users/views/my-page-view/my-page-view.stories.tsx
+++ b/src/entities/users/views/my-page-view/my-page-view.stories.tsx
@@ -1,10 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/react'
-
-import { fn } from '@storybook/test'
 import * as authActions from 'next-auth/react'
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+import { createMock } from 'storybook-addon-module-mock'
 
 import * as userActions from '@/entities/users/actions'
-import { createMock } from 'storybook-addon-module-mock'
+
 import { UserDTO } from '../../types'
 import { MyPageView } from './'
 

--- a/src/lib/backend-api/client.ts
+++ b/src/lib/backend-api/client.ts
@@ -1,7 +1,9 @@
 /* eslint-disable no-console */
 
-import { APP_ENV } from '@/config/env'
 import axios from 'axios'
+
+import { APP_ENV } from '@/config/env'
+
 import { assertAccessToken } from '../utils'
 import { ApiEndpoint } from './api-end-point'
 import { Response } from './type'

--- a/src/lib/faker/index.ts
+++ b/src/lib/faker/index.ts
@@ -1,4 +1,4 @@
-import { Faker, base, ko } from '@faker-js/faker'
+import { base, Faker, ko } from '@faker-js/faker'
 
 export const faker = new Faker({
   locale: [ko, base],

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,8 +1,9 @@
-import tailwindConfig from '@/../tailwind.config'
-import { auth } from '@/app/api/auth/[...nextauth]/auth'
-import { clsx, type ClassValue } from 'clsx'
+import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 import resolveConfig from 'tailwindcss/resolveConfig'
+
+import tailwindConfig from '@/../tailwind.config'
+import { auth } from '@/app/api/auth/[...nextauth]/auth'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))

--- a/src/views/archive-create/index.tsx
+++ b/src/views/archive-create/index.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface ArchiveCreateProps extends HTMLAttributes<HTMLDivElement> {}
 
 /**

--- a/src/views/archive-detail/index.tsx
+++ b/src/views/archive-detail/index.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface ArchiveDetailProps extends HTMLAttributes<HTMLDivElement> {}
 /**
  * https://www.figma.com/design/300FZcKnRKJSVsVLdTxQeN/%F0%9F%92%AC-Sulsul_team?m=dev&node-id=4055-6549&t=OZrGkP4ZgEF84mEl-1

--- a/src/views/archive-list/index.tsx
+++ b/src/views/archive-list/index.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface ArchiveListViewProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const ArchiveListView = ({

--- a/src/views/dashboard/index.tsx
+++ b/src/views/dashboard/index.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface DashboardProps extends HTMLAttributes<HTMLDivElement> {}
 
 /**

--- a/src/views/landing/page.tsx
+++ b/src/views/landing/page.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface LandingProps extends HTMLAttributes<HTMLDivElement> {}
 
 export const Landing = ({ className, ...props }: LandingProps) => {

--- a/src/views/my-page/index.tsx
+++ b/src/views/my-page/index.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface MyPageProps extends HTMLAttributes<HTMLDivElement> {}
 
 /**

--- a/src/views/onboarding/index.tsx
+++ b/src/views/onboarding/index.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface OnboardingProps extends HTMLAttributes<HTMLDivElement> {}
 /**
  *  https://www.figma.com/design/300FZcKnRKJSVsVLdTxQeN/%F0%9F%92%AC-Sulsul_team?m=dev&node-id=4251-7729&t=OZrGkP4ZgEF84mEl-1

--- a/src/views/practice-complete/index.tsx
+++ b/src/views/practice-complete/index.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface PracticeCompleteProps extends HTMLAttributes<HTMLDivElement> {}
 
 /**

--- a/src/views/practice-history/index.tsx
+++ b/src/views/practice-history/index.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface PracticeHistoryProps extends HTMLAttributes<HTMLDivElement> {}
 
 /**

--- a/src/views/practicing/index.tsx
+++ b/src/views/practicing/index.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface PracticingProps extends HTMLAttributes<HTMLDivElement> {}
 
 /**

--- a/src/views/sign-in/index.tsx
+++ b/src/views/sign-in/index.tsx
@@ -1,5 +1,6 @@
-import { cn } from '@/lib/utils'
 import { HTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
 interface SignInProps extends HTMLAttributes<HTMLDivElement> {}
 /**
  *  https://www.figma.com/design/300FZcKnRKJSVsVLdTxQeN/%F0%9F%92%AC-Sulsul_team?m=dev&node-id=4251-7383&t=hglQSnk5HamA3VsA-1


### PR DESCRIPTION
🌼 작업 내용
- simple-import-sort. typescript, @tanstack/query plugin 추가

- simple-import-sort sorting 예시
  - react, next, 외부 모듈
  - 내부 alias import (@/component, 등등)
  - 그 외 상대결로
  - css 파일
  
🌸 수정 사항
- eslint 룰 에 맞춘 파일 수정
- husky에서 검사하던 eslint warning 을 제거하고 fix로 변경 (error만 캐치하기 위함)
- eslint 룰이 기존에는 typescript 관련하여 존재하지 않았기에 typescript rule을 키면 사용하지 않던 변수,함수,type등에서 error가 많이 떨어져서 잠시 걷어놓은 상태 (로직 파악 후 수정할 필요가 있어보입니다.)
- @tanstack/query react-query 권장 eslint rule 추가 

🙏 리뷰 부탁 사항
- 설정 관련이라 바로 develop으로 진행하겠습니다 각자 base에 머지 후 작업 하면 될 것 같아요

👌 테스트
- 테스트한 내용 및 사진을 공유해주세요.(선택)