### PR TITLE
feat: refreshtoken 함수 생성 및 jwt 콜백에 적용

### DIFF
--- a/src/app/api/auth/[...nextauth]/auth.ts
+++ b/src/app/api/auth/[...nextauth]/auth.ts
@@ -35,10 +35,6 @@ export async function refreshAccessToken(token: JWT): Promise<JWT> {
 
     const decodedToken = jwtDecode(refreshedAuth.accessToken);
     const newExpirationTime = (decodedToken.exp as number) * 1000;
-    console.log(
-      'new!!! => ',
-      new Date(newExpirationTime as number).toISOString(),
-    );
 
     refreshAttempts = 0;
 
@@ -81,6 +77,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           token.auth = authDTO;
           token.accessToken = authDTO.accessToken;
           token.refreshToken = authDTO.refreshToken;
+          const decodedToken = jwtDecode(authDTO.accessToken);
+          token.accessTokenExpires = (decodedToken.exp as number) * 1000;
+          return token;
         } else if (account.provider === 'kakao') {
           if (!account.access_token) {
             throw new Error('Kakao access_token is undefined');
@@ -94,12 +93,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           token.accessToken = authDTO.accessToken;
           token.refreshToken = authDTO.refreshToken;
           const decodedToken = jwtDecode(authDTO.accessToken);
-          token.accessTokenExpires = (decodedToken.exp as number) * 1000; // 밀리초로 변환
-          console.log(
-            'Initial token expiration:',
-            new Date(token.accessTokenExpires as number).toISOString(),
-          );
-
+          token.accessTokenExpires = (decodedToken.exp as number) * 1000;
           return token;
         }
       }
@@ -137,9 +131,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
               accessToken: token.auth.accessToken,
             });
             token.data = userDTO;
-            console.log('User data fetched successfully');
           } catch (error) {
-            console.error('Error fetching user data:', error);
             token.error = 'FetchUserError';
           }
         }
@@ -164,7 +156,6 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       if (token.data) {
         session.user.data = { ...token.data };
       }
-      console.log('diffrent session ', token);
       return session;
     },
   },

--- a/src/entities/auth/actions/refresh-action.ts
+++ b/src/entities/auth/actions/refresh-action.ts
@@ -22,7 +22,6 @@ export const refreshAction = async ({
         refreshToken,
       },
     });
-    console.log('Refresh API response:', response);
     return response;
   } catch (error) {
     console.error('Refresh API error:', error);

--- a/src/entities/auth/actions/refresh-action.ts
+++ b/src/entities/auth/actions/refresh-action.ts
@@ -10,15 +10,22 @@ export interface RefreshActionParams {
   refreshToken: string;
 }
 
-export const refreshAction = ({
+export const refreshAction = async ({
   userId,
   refreshToken,
 }: RefreshActionParams) => {
-  return backendApi<RefreshAuthDTO>({
-    endpoint: API_ENDPOINT.auth.refreshAuth(),
-    data: {
-      userId,
-      refreshToken,
-    },
-  });
+  try {
+    const response = await backendApi<RefreshAuthDTO>({
+      endpoint: API_ENDPOINT.auth.refreshAuth(),
+      data: {
+        userId,
+        refreshToken,
+      },
+    });
+    console.log('Refresh API response:', response);
+    return response;
+  } catch (error) {
+    console.error('Refresh API error:', error);
+    throw error;
+  }
 };

--- a/src/lib/backend-api/client.ts
+++ b/src/lib/backend-api/client.ts
@@ -21,15 +21,15 @@ function makeAxiosInstance() {
   instance.interceptors.request.use(
     (config) => {
       // Do something before request is sent
-      // console.log('🔺 Request:', {
-      //   ...config,
-      //   headers: { ...config.headers },
-      // });
+      console.log('🔺 Request:', {
+        ...config,
+        headers: { ...config.headers },
+      });
       return config;
     },
     (error) => {
       // Do something with request error
-      // console.error('❌ Request Error:', error);
+      console.error('❌ Request Error:', error);
       return Promise.reject(error);
     },
   );
@@ -37,10 +37,10 @@ function makeAxiosInstance() {
   // Add a response interceptor
   instance.interceptors.response.use(
     (response) => {
-      // console.log('🔻 Response', {
-      //   config: response.config,
-      //   data: response.data,
-      // });
+      console.log('🔻 Response', {
+        config: response.config,
+        data: response.data,
+      });
       // Any status code that lie within the range of 2xx cause this function to trigger
       // Do something with response data
       return response;
@@ -50,49 +50,14 @@ function makeAxiosInstance() {
       // Do something with response error
       if (error.response) {
         // Server responded with a status other than 2xx
-        //   console.error('⚠️ Response Error:', error.response);
+        console.error('⚠️ Response Error:', error.response);
       } else if (error.request) {
         // Request was made but no response was received
-        //    console.error('🔌 No Response:', error.request);
+        console.error('🔌 No Response:', error.request);
       } else {
         // Something happened in setting up the request
-        //   console.error('🚨 Error:', error.message);
+        console.error('🚨 Error:', error.message);
       }
-      // refresh token을 적용할 순 있지만 session을 업데이트하진 못함
-      // const originalRequest = error.config;
-      // console.log('originalRequest==>', originalRequest);
-      // if (error.response?.status === 401 && !originalRequest._retry) {
-      //   originalRequest._retry = true;
-      //   console.log('401 Error, attempting to refresh token');
-
-      //   try {
-      //     const session = await auth();
-      //     if (!session || !session.user) {
-      //       throw new Error('No active session');
-      //     }
-
-      //     const refreshedToken = await refreshAccessToken(session.user);
-      //     console.log('refreshedToken=>', refreshedToken);
-      //     if (refreshedToken && !refreshedToken.error) {
-      //       // 새로운 토큰으로 원래 요청 재시도
-      //       originalRequest.headers['Authorization'] =
-      //         `Bearer ${refreshedToken.accessToken}`;
-
-      //       if (typeof window === 'undefined') {
-      //         const updatedSession = await auth();
-      //         if (updatedSession) {
-      //           console.log(updatedSession);
-      //         }
-      //       }
-      //       return instance(originalRequest);
-      //     } else {
-      //       throw new Error('Failed to refresh token');
-      //     }
-      //   } catch (refreshError) {
-      //     console.error('Error during token refresh:', refreshError);
-      //     return Promise.reject(refreshError);
-      //   }
-      // }
 
       return Promise.reject(error);
     },

--- a/src/lib/backend-api/client.ts
+++ b/src/lib/backend-api/client.ts
@@ -21,15 +21,15 @@ function makeAxiosInstance() {
   instance.interceptors.request.use(
     (config) => {
       // Do something before request is sent
-      console.log('🔺 Request:', {
-        ...config,
-        headers: { ...config.headers },
-      });
+      // console.log('🔺 Request:', {
+      //   ...config,
+      //   headers: { ...config.headers },
+      // });
       return config;
     },
     (error) => {
       // Do something with request error
-      console.error('❌ Request Error:', error);
+      // console.error('❌ Request Error:', error);
       return Promise.reject(error);
     },
   );
@@ -37,32 +37,68 @@ function makeAxiosInstance() {
   // Add a response interceptor
   instance.interceptors.response.use(
     (response) => {
-      console.log('🔻 Response', {
-        config: response.config,
-        data: response.data,
-      });
+      // console.log('🔻 Response', {
+      //   config: response.config,
+      //   data: response.data,
+      // });
       // Any status code that lie within the range of 2xx cause this function to trigger
       // Do something with response data
       return response;
     },
-    (error) => {
+    async (error) => {
       // Any status codes that falls outside the range of 2xx cause this function to trigger
       // Do something with response error
       if (error.response) {
         // Server responded with a status other than 2xx
-        console.error('⚠️ Response Error:', error.response);
+        //   console.error('⚠️ Response Error:', error.response);
       } else if (error.request) {
         // Request was made but no response was received
-        console.error('🔌 No Response:', error.request);
+        //    console.error('🔌 No Response:', error.request);
       } else {
         // Something happened in setting up the request
-        console.error('🚨 Error:', error.message);
+        //   console.error('🚨 Error:', error.message);
       }
+      // refresh token을 적용할 순 있지만 session을 업데이트하진 못함
+      // const originalRequest = error.config;
+      // console.log('originalRequest==>', originalRequest);
+      // if (error.response?.status === 401 && !originalRequest._retry) {
+      //   originalRequest._retry = true;
+      //   console.log('401 Error, attempting to refresh token');
+
+      //   try {
+      //     const session = await auth();
+      //     if (!session || !session.user) {
+      //       throw new Error('No active session');
+      //     }
+
+      //     const refreshedToken = await refreshAccessToken(session.user);
+      //     console.log('refreshedToken=>', refreshedToken);
+      //     if (refreshedToken && !refreshedToken.error) {
+      //       // 새로운 토큰으로 원래 요청 재시도
+      //       originalRequest.headers['Authorization'] =
+      //         `Bearer ${refreshedToken.accessToken}`;
+
+      //       if (typeof window === 'undefined') {
+      //         const updatedSession = await auth();
+      //         if (updatedSession) {
+      //           console.log(updatedSession);
+      //         }
+      //       }
+      //       return instance(originalRequest);
+      //     } else {
+      //       throw new Error('Failed to refresh token');
+      //     }
+      //   } catch (refreshError) {
+      //     console.error('Error during token refresh:', refreshError);
+      //     return Promise.reject(refreshError);
+      //   }
+      // }
+
       return Promise.reject(error);
     },
   );
 
-  return instance; // Make sure to return the instance
+  return instance;
 }
 
 export interface BackendApiParams {
@@ -78,19 +114,24 @@ export const backendApi = async <T>({
   params,
   accessToken,
 }: BackendApiParams) => {
-  const axios = makeAxiosInstance();
+  const axiosInstance = makeAxiosInstance();
   const { url, method, authorization } = endpoint;
-  if (authorization) {
-    axios.defaults.headers.common['Authorization'] =
-      `Bearer ${accessToken ?? (await assertAccessToken())}`;
+
+  try {
+    if (authorization) {
+      axiosInstance.defaults.headers.common['Authorization'] =
+        `Bearer ${accessToken ?? (await assertAccessToken())}`;
+    }
+
+    const res = (await axiosInstance({
+      url,
+      method,
+      data,
+      params,
+    })) as { data: Response<T> };
+
+    return res.data.data;
+  } catch (error) {
+    console.error('Axios request error:', error);
   }
-
-  const res = (await axios({
-    url,
-    method,
-    data,
-    params,
-  })) as { data: Response<T> };
-
-  return res.data.data;
 };


### PR DESCRIPTION
🌼 작업 내용

- refreshToken 작업
- jwt 콜백에서 처음에 로그인할 때 받은 accesstoken의 expire 시간(15분)을 이용해 1분 전에 리프레시 api 호출

### 문제
1. jwt 콜백에 refreshAccessToken이 무한 호출되어 방지하고자 했지만 여러번 호출됨
2. accessToken이 만료되기전에 바꾸기 때문에 401에러가 안날거라고 생각했지만, 나는 경우가 있음
 - 이걸 해결하고자 interceptor와 middleware에서 401에러 받으면 refreshAccessToken함수 호출 시도
 -> 호출은 잘 돼서 헤더에 새 토큰을 넣을 수 있지만 session을 업데이트할 수 없음(client.ts 주석 부분)
 -> session 수정은 콜백에서만 가능한듯함..?!

배포해서 확인해봤을 때 갱신이 잘 되는가 싶다가도 안되는 순간이 있고.. 로그에 refresh api 여러번 호출한게 남아서 이걸 합쳐도 될지 고민이 되는거 같아요ㅠㅠ
시간 되시는 분 코드 확인 한 번씩만 해주시면 감사하겠습니다..!!
콘솔은 리뷰 받고 합쳐도 될 것 같으면 지우겠습니다!!

🌸 수정 사항

- 추가하거나 수정한 사항을 적어주세요.(선택)

🙏 리뷰 부탁 사항

- 리뷰받고 싶은 내용이나 리뷰어에게 전달 할 내용을 적어주세요.(선택)

👌 테스트

- 테스트한 내용 및 사진을 공유해주세요.(선택)
