### PR TITLE
fix: 온보딩중복

### DIFF
--- a/src/app/(landing)/components/hero/desktop/index.tsx
+++ b/src/app/(landing)/components/hero/desktop/index.tsx
@@ -81,6 +81,7 @@ export const DesktopHero = ({ className, ...props }: HeroProps) => {
             <Button
               variant={'black'}
               className="mt-8 px-8 text-base font-semibold sm:text-xl"
+              onClick={() => router.push('/archive/create')}
             >
               내 면접질문 예측하기
             </Button>

--- a/src/app/(landing)/components/onboard/views/onboard-modal-view/index.tsx
+++ b/src/app/(landing)/components/onboard/views/onboard-modal-view/index.tsx
@@ -12,10 +12,9 @@ import { ListDialog } from '../../components/list-dialog';
 import { DialogListProp, OnBoardProp } from '../../types/onboard';
 
 export const OnboardModal = () => {
-  const { nickname, firstLogin } = useUserStore((state) => ({
-    nickname: state.data.nickname,
-    firstLogin: state.data.firstLogin,
-  }));
+  const data = useUserStore((state) => state.data);
+  const setUserInfo = useUserStore((state) => state.setUserInfo);
+
   const [buttonDisable, setButtonDisable] = useState<boolean>(true);
 
   const [step, setStep] = useState<number>(0);
@@ -37,7 +36,7 @@ export const OnboardModal = () => {
           dialogContents: [
             [
               {
-                message: nickname as string,
+                message: data.nickname as string,
                 className: 'font-bold',
               },
               {
@@ -154,7 +153,7 @@ export const OnboardModal = () => {
 
   useEffect(() => {
     setHidden(false);
-    visibility === 'visible' && firstLogin && pause();
+    visibility === 'visible' && data.firstLogin && pause();
     const timerId = setInterval(() => {
       if (step <= dialog[dialogNumber].messageListProp.length) {
         setStep((prev) => (prev += 1));
@@ -175,11 +174,17 @@ export const OnboardModal = () => {
 
   const handleClose = () => {
     restart();
+    setUserInfo({
+      data: {
+        ...data,
+        firstLogin: false,
+      },
+    });
     setVisibility('hidden');
   };
 
   return (
-    firstLogin && (
+    data.firstLogin && (
       <div
         className={cn(
           'fixed flex justify-center items-center w-screen z-[50] h-screen bg-gray-800/80 mobile:hidden',

--- a/src/components/layouts/header/desktop-header/index.tsx
+++ b/src/components/layouts/header/desktop-header/index.tsx
@@ -38,7 +38,6 @@ export const DesktopHeader = ({ className, ...props }: DesktopHeaderProps) => {
   const { pause } = useVideoStateStore();
   const { data, image } = useUserStore();
   const [isLoggingIn, setIsLoggingIn] = useState(false);
-  const clearUserInfoStorage = useUserStore.persist.clearStorage;
 
   useEffect(() => {
     if (status === 'authenticated') {
@@ -105,7 +104,7 @@ export const DesktopHeader = ({ className, ...props }: DesktopHeaderProps) => {
               className="cursor-pointer gap-2 px-5 py-4 text-base font-medium"
               onClick={() => {
                 signOut({ callbackUrl: '/' });
-                clearUserInfoStorage();
+                useUserStore.persist.clearStorage();
               }}
             >
               <Image

--- a/src/components/layouts/header/desktop-header/index.tsx
+++ b/src/components/layouts/header/desktop-header/index.tsx
@@ -38,6 +38,7 @@ export const DesktopHeader = ({ className, ...props }: DesktopHeaderProps) => {
   const { pause } = useVideoStateStore();
   const { data, image } = useUserStore();
   const [isLoggingIn, setIsLoggingIn] = useState(false);
+  const clearUserInfoStorage = useUserStore.persist.clearStorage;
 
   useEffect(() => {
     if (status === 'authenticated') {
@@ -104,6 +105,7 @@ export const DesktopHeader = ({ className, ...props }: DesktopHeaderProps) => {
               className="cursor-pointer gap-2 px-5 py-4 text-base font-medium"
               onClick={() => {
                 signOut({ callbackUrl: '/' });
+                clearUserInfoStorage();
               }}
             >
               <Image

--- a/src/components/layouts/header/mobile-header/index.tsx
+++ b/src/components/layouts/header/mobile-header/index.tsx
@@ -42,8 +42,6 @@ export const MobileHeader = ({ className, ...props }: MobileHeaderProps) => {
   const [openSheet, setOpenSheet] = useState(false);
   const copiedLink = 'https://www.sulsul-interview.kr/';
   const router = useRouter();
-  const clearUserInfoStorage = useUserStore.persist.clearStorage;
-
   return (
     <header
       className={cn('flex h-full items-center justify-between py-4', className)}
@@ -170,7 +168,7 @@ export const MobileHeader = ({ className, ...props }: MobileHeaderProps) => {
                             className="flex cursor-pointer items-center gap-4"
                             onClick={() => {
                               signOut({ callbackUrl: '/' });
-                              clearUserInfoStorage();
+                              useUserStore.persist.clearStorage();
                             }}
                           >
                             <Image

--- a/src/components/layouts/header/mobile-header/index.tsx
+++ b/src/components/layouts/header/mobile-header/index.tsx
@@ -30,7 +30,6 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
-import { APP_ROUTES } from '@/config/constants/app-routes';
 import { MobileHeaderLinks } from '@/config/constants/navigation-links';
 import { SignInView } from '@/entities/auth/views/sign-in-view';
 import { cn } from '@/lib/utils';
@@ -43,6 +42,8 @@ export const MobileHeader = ({ className, ...props }: MobileHeaderProps) => {
   const [openSheet, setOpenSheet] = useState(false);
   const copiedLink = 'https://www.sulsul-interview.kr/';
   const router = useRouter();
+  const clearUserInfoStorage = useUserStore.persist.clearStorage;
+
   return (
     <header
       className={cn('flex h-full items-center justify-between py-4', className)}
@@ -169,6 +170,7 @@ export const MobileHeader = ({ className, ...props }: MobileHeaderProps) => {
                             className="flex cursor-pointer items-center gap-4"
                             onClick={() => {
                               signOut({ callbackUrl: '/' });
+                              clearUserInfoStorage();
                             }}
                           >
                             <Image

--- a/src/entities/practice/components/practice-start-card/index.tsx
+++ b/src/entities/practice/components/practice-start-card/index.tsx
@@ -145,7 +145,7 @@ export const PracticeStartCard = ({
       </div>
       <AuthSignedIn>
         <Button
-          className=" hidden w-full desktop:flex"
+          className="w-full mobile:hidden"
           onClick={() => setModalOpen(true)}
         >
           실전연습하기

--- a/src/entities/practice/practice-modal/components/practice-modal-resume-section/index.tsx
+++ b/src/entities/practice/practice-modal/components/practice-modal-resume-section/index.tsx
@@ -1,8 +1,10 @@
 'use client';
 import { Dispatch, SetStateAction, useEffect } from 'react';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { CheckedState } from '@radix-ui/react-checkbox';
 
+import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ArchiveListItemDTO } from '@/entities/types';
 import { cn } from '@/lib/utils';
@@ -30,6 +32,7 @@ export default function PracticeModalResumeSection({
   focusedResume,
   setFocusedResume,
 }: ResumeSectionType) {
+  const router = useRouter();
   return (
     <div className="flex  w-1/2 flex-col">
       <section className="flex h-12 w-full flex-row text-xs leading-5 text-gray-500">
@@ -61,7 +64,10 @@ export default function PracticeModalResumeSection({
             <Checkbox
               id="resumes"
               className="m-[10px] size-5 p-[2px] "
-              checked={resume?.length === selectArchiveIds.length}
+              checked={
+                resume?.length != 0 &&
+                resume?.length === selectArchiveIds.length
+              }
               onCheckedChange={(check: CheckedState) => {
                 if (resume) {
                   check
@@ -79,7 +85,16 @@ export default function PracticeModalResumeSection({
         </div>
       </section>
       <section className="h-[300px] overflow-scroll">
-        {resume &&
+        {resume && resume.length == 0 ? (
+          <div className="flex size-full flex-col items-center justify-center gap-4">
+            <p className="text-xl font-normal text-black">
+              아직 연습할 면접질문이 없습니다
+            </p>
+            <Button onClick={() => router.push('/archive/create')}>
+              면접 질문 생성하러가기
+            </Button>
+          </div>
+        ) : (
           resume.map((value: ArchiveListItemDTO, index) => {
             return (
               <MyResumeSelection
@@ -93,7 +108,8 @@ export default function PracticeModalResumeSection({
                 setFocusedResume={setFocusedResume}
               />
             );
-          })}
+          })
+        )}
       </section>
     </div>
   );

--- a/src/entities/practice/practice-modal/index.tsx
+++ b/src/entities/practice/practice-modal/index.tsx
@@ -49,11 +49,7 @@ export default function PracticeSelection({
 
   const { resume } = useResumes();
   const [focusedResume, setFocusedResume] = useState(
-    resumeId !== 0
-      ? resumeId
-      : resume && resume[0].archiveId
-        ? resume[0].archiveId
-        : 0,
+    resumeId !== 0 ? resumeId : resume && resume[0] ? resume[0].archiveId : 0,
   );
 
   useEffect(() => {

--- a/src/entities/users/components/drop-out/index.tsx
+++ b/src/entities/users/components/drop-out/index.tsx
@@ -21,7 +21,10 @@ export const DropOut = ({ className, ...props }: DropOutProps) => {
           </button>
         </AlertDialogTrigger>
         <AlertModal
-          onClick={() => withdrawUserMutation({ userId })}
+          onClick={() => {
+            withdrawUserMutation({ userId }),
+              useUserStore.persist.clearStorage();
+          }}
           title="정말 탈퇴하시겠어요?"
           desc="탈퇴 시, 계정은 삭제되며 복구되지 않아요."
           action="탈퇴하기"

--- a/src/entities/users/hooks/use-current-user.ts
+++ b/src/entities/users/hooks/use-current-user.ts
@@ -7,6 +7,7 @@ import { useUserStore } from '@/store/client';
 
 export const useCurrentUser = () => {
   const { data, status, update } = useSession();
+  const userInfo = useUserStore((state) => state.data);
   const setUserInfo = useUserStore((state) => state.setUserInfo);
 
   useEffect(() => {
@@ -22,7 +23,7 @@ export const useCurrentUser = () => {
           job: data.user.data?.job || { jobId: 0, name: '' },
           nickname: data.user.data?.nickname || '',
           userId: data.user.auth?.userId || 0,
-          firstLogin: data.user.data?.firstLogin || false,
+          firstLogin: data.user.data?.firstLogin ? userInfo.firstLogin : false,
           firstPractice: data.user.data?.firstPractice || false,
         },
         image: data.user.image || '',

--- a/src/store/client.ts
+++ b/src/store/client.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 interface PendingState {
   isPending: boolean;
@@ -37,34 +38,42 @@ export interface UserState {
   setUserInfo: (userInfo: Partial<UserState>) => void;
 }
 
-export const useUserStore = create<UserState>((set) => ({
-  auth: {
-    userId: 0,
-    accessToken: '',
-    refreshToken: '',
-  },
-  data: {
-    email: '',
-    job: {
-      jobId: 0,
-      name: '',
-    },
-    nickname: '',
-    userId: 0,
-    firstLogin: false,
-    firstPractice: false,
-  },
-  image: '',
-  setUserInfo: (userInfo: Partial<UserState>) =>
-    set((state) => ({
+export const useUserStore = create(
+  persist<UserState>(
+    (set) => ({
       auth: {
-        ...state.auth,
-        ...userInfo.auth,
+        userId: 0,
+        accessToken: '',
+        refreshToken: '',
       },
       data: {
-        ...state.data,
-        ...userInfo.data,
+        email: '',
+        job: {
+          jobId: 0,
+          name: '',
+        },
+        nickname: '',
+        userId: 0,
+        firstLogin: true,
+        firstPractice: false,
       },
-      image: userInfo.image ?? state.image,
-    })),
-}));
+      image: '',
+      setUserInfo: (userInfo: Partial<UserState>) =>
+        set((state) => ({
+          auth: {
+            ...state.auth,
+            ...userInfo.auth,
+          },
+          data: {
+            ...state.data,
+            ...userInfo.data,
+          },
+          image: userInfo.image ?? state.image,
+        })),
+    }),
+    {
+      name: 'userStorage',
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+);


### PR DESCRIPTION
🌼 작업 내용

- 온보딩이 중복으로 나타나는 현상 수정 
- 연습질문 없을때 연습모달 에러 예외처리 

🌸 수정 사항
- 새로고침 또는 페이지 이동할때 초기화되는 state 를 zustand persist 사용해서 sessionStorage 에 저장 

🙏 리뷰 부탁 사항

- persist로 유저 정보를 새로고침해도 저장했는데 더 좋은 방법 또는 persist로 문제되는 부분 있으면 언제든 말씀해주세요.  

👌 테스트

- 테스트한 내용 및 사진을 공유해주세요.(선택)
